### PR TITLE
take command-line arguments

### DIFF
--- a/ipa_print.py
+++ b/ipa_print.py
@@ -1,0 +1,7 @@
+import sys
+from text import Text
+
+if __name__ == "__main__":
+    a = sys.argv[1]
+    b = Text(a.decode('utf8'))
+    b.print_dict_ipa()

--- a/part.py
+++ b/part.py
@@ -74,7 +74,7 @@ class Pref(Part):
             else:
 
                 # remove stress from first prefix if it has one
-                if newipa[0] == "ˈ":
+                if newipa[0].encode('utf-8') == "ˈ":
                     newipa = newipa[1:]
 
                 # check if previous pref was special case: 'hin', 'her', 'dar' or 'vor'

--- a/text.py
+++ b/text.py
@@ -44,6 +44,16 @@ class Text(object):
             else:
                 print (line.adjustedline)
 
+    def print_dict_ipa(self):
+        """
+        Prints each line of text with IPA separated by tabs.
+        """
+        for line in self.each_line:
+            if not (line.adjustedline.isspace() or (line.adjustedline == '')):
+                print (line.adjustedline + "\t" + line.ipa).encode('utf-8')
+            else:
+                print (line.adjustedline)
+
 
 class Line(object):
     """


### PR DESCRIPTION
This adds a small script (`ipa_print.py`) that allows for querying the main germanipa script from the command-line.

Usage: `python ipa_print.py [WORD / PHRASE]`
